### PR TITLE
[v1.0.0] --> [main] Add support for colored log and exports

### DIFF
--- a/src/miroslava/utils/__init__.py
+++ b/src/miroslava/utils/__init__.py
@@ -1,0 +1,7 @@
+from .common import *
+from .logger import *
+
+__all__ = (
+    common.__all__
+    + logger.__all__
+)


### PR DESCRIPTION
**Added:**
- A new `StreamHandler` class which adds support for colored logging on a TTY interface. The class allows for coloring specific record attrs or only the logging levels.
- Support for controlling exports using `__all__` in the `__init__.py`. This allows us to control the behavior of the submodules defined in the `utils` directory.

**Changed:**
- `Formatter.formatPath` now replaces the `record.msg` instead of replacing the output. This makes the solution more reliable and less of a hack!
- Minor docstring corrections.