### PR TITLE
[v1.0.0] --> [main] Upstream major changes to tox and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ pyrightconfig.json
 
 # Scratchpad for experiments
 .scratch/
+*.bak

--- a/docs/commit.txt
+++ b/docs/commit.txt
@@ -1,0 +1,36 @@
+FORMAT FOR COMMITING TO MIROSLAVA
+---------------------------------
+
+[v{{ Main version }}] Commit title (should not be more than 50 characters)
+Date of commit in MMM DD, YYYY format - Version with development/release numbers
+
+Added:
+- Description of the code/file(s)/object(s) added to the repository/project.
+  Length of description should be less than 72 characters. The description
+  can span multiple lines and if so happen should be indent with 2 spaces.
+  The same is applicable for below sections.
+
+Changed:
+- Description of the code/object(s) changed or modified from the repository/file.
+
+Fixed:
+- Description of the bug/issue/problem fixed. Add link to the issue/bug if possible.
+
+Removed:
+- Description of the code/file(s)/object(s) that have been replaced/removed or
+  deleted from the repository/file.
+
+
+SAMPLE COMMIT
+-------------
+
+[v1.0.0] Add more internal constants
+Apr 11, 2020 - v1.0.0.dev.1
+
+Added:
+- New constants like `NEW_CONSTANT_1`, `NEW_CONSTANT_2`, `NEW_CONSTANT_3`
+  and `NEW_CONSTANT_4` with descriptions in `miroslava.config.internals`
+
+Changed:
+- `USR` is now `SESSION_USER` and `SEP` is now `PATH_SEP`. This provides more
+  clarity and makes the usage more non-esoteric in nature.

--- a/src/miroslava/utils/__init__.py
+++ b/src/miroslava/utils/__init__.py
@@ -1,7 +1,4 @@
 from .common import *
 from .logger import *
 
-__all__ = (
-    common.__all__
-    + logger.__all__
-)
+__all__ = common.__all__ + logger.__all__

--- a/src/miroslava/utils/common.py
+++ b/src/miroslava/utils/common.py
@@ -38,6 +38,8 @@ class Singleton(type):
         <__main__.SomeClass object at 0x7f3f2d7db820>
         >>> x2
         <__main__.SomeClass object at 0x7f3f2d7db820>
+        >>> x1 is x2
+        True
         >>>
 
     References:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,19 @@
+from miroslava.utils import Singleton, TTYPalette
+
+
+class TestSingletonClass(metaclass=Singleton):
+    pass
+
+
+def test_singleton():
+    x1 = TestSingletonClass()
+    x2 = TestSingletonClass()
+    assert x1 is x2
+    assert x1 == x2
+
+
+def test_ttypalette():
+    orange = TTYPalette.ORANGE_1
+    plum = TTYPalette.PLUM_1
+    assert orange == "\u001b[38;5;214m"
+    assert plum == "\u001b[38;5;219m"

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,19 @@
 [tox]
-minversion = 3.4.0
-envlist = py{36,37,38,39}
+envlist = python{3.6,3.7,3.8,3.9},black-lint-matters
+minversion = 3.12
 isolated_build = true
 skip_missing_interpreters = true
 
 [testenv]
-deps = 
-    check-manifest >= 0.42
-    flake8
-    pytest
-commands = 
-    check-manifest --ignore 'tox.ini,tests/**'
-    python setup.py check -m -s
-    flake8 .
-    py.test {posargs:tests}
+deps = pytest
+commands =
+    python setup.py check -s -m
+    pytest {posargs:tests}
 
-[flake8]
-exclude = .tox,*.egg,build,data
-select = E,W,F
+[testenv:black-lint-matters]
+deps =
+    black
+    check-manifest
+commands =
+    black src/miroslava tests setup.py
+    check-manifest --ignore 'tox.ini,tests/**'


### PR DESCRIPTION
**Added:**
- Git commit format document. This document offers a sample git commit message format.
- Tests for common module.

**Changed:**
- Tox now drops `flake8` and `testenvs` just do the testing. Test envs and linter envs are separated.
- `Black` is used as default code formatter.
- Files with `.bak` extensions are now ignored.
- Minor code refactor and docstring corrections.