### PR TITLE
[v1.0.0] --> [main] Upstream project changes and use flake8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,11 @@ include = """
 """
 exclude = """
 (
+    .git
+    .mypy_cache
+    .tox
     __pycache__
+    build
+    dist
 )
 """

--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,9 @@ setup(
     install_requires=dependencies,
     extras_require={
         "dev": [
-            "autopep8",
             "black",
             "check-manifest",
+            "flake8",
             "pytest",
             "pytest-cov",
             "tox",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = python{3.6,3.7,3.8,3.9},black-lint-matters
+envlist = python{3.6,3.7,3.8,3.9},pep8
 minversion = 3.12
 isolated_build = true
 skip_missing_interpreters = true
@@ -10,10 +10,18 @@ commands =
     python setup.py check -s -m
     pytest {posargs:tests}
 
-[testenv:black-lint-matters]
+[testenv:pep8]
 deps =
     black
     check-manifest
+    flake8
 commands =
-    black src/miroslava tests setup.py
-    check-manifest --ignore 'tox.ini,tests/**'
+    check-manifest --ignore 'tox.ini,docs/**,tests/**'
+    black src/miroslava tests/ setup.py
+    flake8 src/miroslava tests/ setup.py
+
+[flake8]
+exclude = .tox,.git,*.egg,__pycache__,build,data
+select = E,W,F
+ignore = E203, F403, F405, E501, E731
+max-complexity = 18


### PR DESCRIPTION
**Added:**
- Support for `Flake8` as default code checker in tox.
- Directories to exclude in `pyproject.toml`.