### PR TITLE
[v1.0.0] --> [main] Add new constants & change logger message

### DIFF
--- a/src/miroslava/config/internal.py
+++ b/src/miroslava/config/internal.py
@@ -8,11 +8,15 @@ OS = sys.platform
 WINDOWS_OS = OS == "win32"
 LOGGED_USER = getpass.getuser()
 
+ROOT = ".miroslava"
 LOGS = "logs"
+CACHE = "cache"
+DATA = "data"
 
 PATH_SEP = _os.sep
 HOME_PATH = _os.expanduser("~")
-ROOT_PATH = _os.join(HOME_PATH, "miroslava")
+ROOT_PATH = _os.join(HOME_PATH, ROOT)
+LOGGER_PATH = _os.join(ROOT_PATH, LOGGED_USER, LOGS)
 
 DEFAULT_DATETIME_FMT = "%Y-%m-%d %H:%M:%S"
 LOGGER_DATETIME_FMT = "%b %d, %Y %H:%M:%S"
@@ -22,7 +26,7 @@ TZONE = "UTC"
 
 LOGGER_MSG_FMT = (
     "%(asctime)s.%(msecs)03d %(levelname)8s %(process)8d "
-    "[%(threadName)16s] %(pathname)30s:%(lineno)d - %(message)s"
+    "[%(threadName)16s] %(caller)30s:%(lineno)03d - %(message)s"
 )
 LOGGER_EXC_FMT = "{}: {} {} line {}"
 


### PR DESCRIPTION
**Added:**
- New constants for directory names.

**Changed:**
- `ROOT_PATH` is accessed via new `ROOT` constant.
- `LOGGER_MSG_FMT` uses new `caller` attribute instead of pathname.