### PR TITLE
[v1.0.0] Cache function calls using lru_cache

### DIFF
--- a/src/miroslava/__init__.py
+++ b/src/miroslava/__init__.py
@@ -1,10 +1,12 @@
-import os.path as _os
 import os
+import os.path as _os
 
 from .config.internal import LOGGER_PATH, ROOT_PATH
 
 if not _os.exists(ROOT_PATH):
     os.mkdir(ROOT_PATH)
 
-for path in (LOGGER_PATH,):
-    os.makedirs(path, exist_ok=True)
+_paths = (LOGGER_PATH,)
+
+for _path in _paths:
+    os.makedirs(_path, exist_ok=True)

--- a/src/miroslava/utils/logger.py
+++ b/src/miroslava/utils/logger.py
@@ -2,6 +2,7 @@
 
 import logging
 import sys
+from functools import lru_cache
 from logging.handlers import RotatingFileHandler as FileHandler
 from os.path import abspath, basename, join, splitext
 from typing import IO, Any, Dict, Optional, Tuple, Union
@@ -15,7 +16,7 @@ from miroslava.config.internal import (
 )
 from miroslava.utils.common import Singleton, TTYPalette
 
-__all__ = ["Formatter", "StreamHandler", "Logger"]
+__all__ = ["Logger", "Formatter", "StreamHandler"]
 
 # NOTE: Most of the docstring is referenced from the original logging
 # module since this logger does not intent to change the behavior of
@@ -90,12 +91,13 @@ class Formatter(logging.Formatter, metaclass=Singleton):
         self.log_fmt = log_fmt
         self.date_fmt = date_fmt
 
+    @lru_cache
     def formatException(self, ei: Tuple) -> str:
         """Format exception information as text.
 
         Please note that this implementation does not work directly.
-        The standard `logging.Formatter()` is required for creating the
-        `str` format of the logged record which adds an unnecessary
+        The standard `logging.Formatter()` is required for creating
+        the `str` format of the logged record which adds an unnecessary
         `\\n` to the output which needs to be skipped.
 
         Args:
@@ -114,6 +116,7 @@ class Formatter(logging.Formatter, metaclass=Singleton):
         exc_tbk = exc_obj, exc_tbk.tb_lineno
         return LOGGER_EXC_FMT.format(exc_cls.__name__, exc_msg, *exc_tbk)
 
+    @lru_cache
     def formatPath(self, path: str, fnc: str, limit: int = 27) -> str:
         """Format path with module-like structure.
 
@@ -142,6 +145,7 @@ class Formatter(logging.Formatter, metaclass=Singleton):
             path = "..." + path[-limit:]
         return path
 
+    @lru_cache
     def format(self, record: logging.LogRecord) -> str:
         """Format the specified record as text.
 
@@ -205,6 +209,7 @@ class StreamHandler(logging.StreamHandler, metaclass=Singleton):
         self.kwargs = {k: getattr(TTYPalette, v) for k, v in kwargs.items()}
         super().__init__(stream=stream)
 
+    @lru_cache
     def format(self, record: logging.LogRecord) -> str:
         """Format the attrs with colors.
 


### PR DESCRIPTION
Added `lru_cache` decorator to reduce the redundant function calls in the `miroslava.utils.logger.Formatter()` and the `miroslava.utils.logger.StreamHandler()` classes.
This change has drastically reduced the number of function calls when profiled, reducing from **972** ncalls to **694** ncalls. Although the ncalls increases rather quickly but the `lru_cache` keeps the count relatively low.

Refactored `for` loop for creating directories in `miroslava` module.