### PR TITLE
[v1.0.0] --> [main] Parametrize tests and remove tox breakage note

### DIFF
--- a/src/miroslava/config/internal.py
+++ b/src/miroslava/config/internal.py
@@ -7,8 +7,6 @@ import sys
 
 OS = sys.platform
 WINDOWS_OS = OS == "win32"
-# NOTE: Tox breaks `getpass.getuser` on Windows
-# https://github.com/tox-dev/tox/issues/1455
 LOGGED_USER = os.getlogin() if WINDOWS_OS else getpass.getuser()
 
 ROOT = ".miroslava"

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,3 +1,4 @@
+import pytest
 from miroslava.utils import Singleton, TTYPalette
 
 
@@ -12,8 +13,13 @@ def test_singleton():
     assert x1 == x2
 
 
-def test_ttypalette():
-    orange = TTYPalette.ORANGE_1
-    plum = TTYPalette.PLUM_1
-    assert orange == "\u001b[38;5;214m"
-    assert plum == "\u001b[38;5;219m"
+@pytest.mark.parametrize(
+    ("color", "code"),
+    (
+        ("GOLD_1", "\u001b[38;5;220m"),
+        ("ORANGE_1", "\u001b[38;5;214m"),
+        ("PLUM_1", "\u001b[38;5;219m"),
+    ),
+)
+def test_ttypalette(color, code):
+    assert getattr(TTYPalette, color) == code


### PR DESCRIPTION
- Migrated to `pytest.mark.parametrize` over multiple tests to simplify the testing suite.
- Remove Tox related issue note from the `miroslava.config.internal` module as the issue is fixed.

See this: https://github.com/kaamiki/miroslava/pull/39/commits/c059361138040b2f2e89b2d8fb39a67a8d86bd33