### PR TITLE
[v1.1.0] --> [main] Drop config.colors for palette

### DIFF
--- a/src/miroslava/palette.py
+++ b/src/miroslava/palette.py
@@ -1,4 +1,4 @@
-"""Color options for web and tty interfaces"""
+"""Palette: Color palette for web and tty interfaces"""
 
 TTY_COLOR_AQUA = "\u001b[38;5;14m"
 TTY_COLOR_AQUAMARINE_1 = "\u001b[38;5;122m"


### PR DESCRIPTION
Dropped `miroslava.config.colors` and replaced by , `miroslava.palette`.
This change ensures that there is no dependency for a dedicated `config`
module.