### PR TITLE
Upstream miscellaneous changes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,5 @@ include setup.py
 
 exclude .travis.yml
 exclude tox.ini
+
+recursive-include src *.typed 

--- a/src/miroslava/__init__.py
+++ b/src/miroslava/__init__.py
@@ -6,7 +6,6 @@ except ImportError:
     __version__ = "0.0.0"
 
 from _miroslava import palette
-from _miroslava.track import BaseProtocol
 from _miroslava.utils import FileHandler
 from _miroslava.utils import Formatter
 from _miroslava.utils import Handler
@@ -25,7 +24,6 @@ from _miroslava.utils import stdout
 
 __all__ = [
     "palette",
-    "BaseProtocol",
     "FileHandler",
     "Formatter",
     "Handler",

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,9 +1,9 @@
 import pytest
-from miroslava.utils import Singleton
-from miroslava.utils import TTYPalette
+from miroslava import SingletonMeta
+from miroslava import TTYPalette
 
 
-class TestSingletonClass(metaclass=Singleton):
+class TestSingletonClass(metaclass=SingletonMeta):
     pass
 
 
@@ -15,12 +15,12 @@ def test_singleton() -> None:
 
 
 @pytest.mark.parametrize(
-    ("color", "code"),
+    ("color", "expected"),
     (
         ("GOLD_1", "\u001b[38;5;220m"),
         ("ORANGE_1", "\u001b[38;5;214m"),
         ("PLUM_1", "\u001b[38;5;219m"),
     ),
 )
-def test_ttypalette(color: str, code: str) -> None:
-    assert getattr(TTYPalette, color) == code
+def test_ttypalette(color: str, expected: str) -> None:
+    assert getattr(TTYPalette, color) == expected

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,129 @@
+from typing import Any
+
+import pytest
+from miroslava import Logger
+from miroslava import create_logger
+
+
+def dummy_log_function(
+    logger: Logger, msg: str, level: str, **extra: Any
+) -> None:
+    getattr(logger, level)(msg, extra=extra)
+
+
+default_formatter_expected_msg = (
+    "{} [MainThread] tests.test_logging."
+    "dummy_log_function:11 : Test {} message with default formatter\n"
+)
+
+
+@pytest.mark.parametrize(
+    ("msg", "level", "expected"),
+    (
+        (
+            "Test debug message with default formatter",
+            "debug",
+            "",
+        ),
+        (
+            "Test info message with default formatter",
+            "info",
+            default_formatter_expected_msg.format("INFO", "info"),
+        ),
+        (
+            "Test warning message with default formatter",
+            "warn",
+            default_formatter_expected_msg.format("WARN", "warning"),
+        ),
+        (
+            "Test error message with default formatter",
+            "error",
+            default_formatter_expected_msg.format("ERROR", "error"),
+        ),
+    ),
+)
+def test_with_default_format(
+    capsys: Any, msg: str, level: str, expected: str
+) -> None:
+    logger = create_logger()
+    dummy_log_function(logger, msg, level)
+    _, stderr = capsys.readouterr()
+    assert stderr[20:] == expected
+
+
+custom_formatter_expected_msg = (
+    "{}:root:Test {} message with custom formatter\n"
+)
+
+
+@pytest.mark.parametrize(
+    ("msg", "level", "expected"),
+    (
+        (
+            "Test debug message with custom formatter",
+            "debug",
+            "",
+        ),
+        (
+            "Test info message with custom formatter",
+            "info",
+            custom_formatter_expected_msg.format("INFO", "info"),
+        ),
+        (
+            "Test warning message with custom formatter",
+            "warn",
+            custom_formatter_expected_msg.format("WARN", "warning"),
+        ),
+        (
+            "Test error message with custom formatter",
+            "error",
+            custom_formatter_expected_msg.format("ERROR", "error"),
+        ),
+    ),
+)
+def test_with_custom_format(
+    capsys: Any, msg: str, level: str, expected: str
+) -> None:
+    logger = create_logger(format="%(levelname)s:%(name)s:%(message)s")
+    dummy_log_function(logger, msg, level)
+    _, stderr = capsys.readouterr()
+    assert stderr == expected
+
+
+formatter_with_extra_expected_msg = (
+    "127.0.0.1:6969 - Test {} message with extra args\n"
+)
+
+
+@pytest.mark.parametrize(
+    ("msg", "level", "expected"),
+    (
+        (
+            "Test debug message with extra args",
+            "debug",
+            "",
+        ),
+        (
+            "Test info message with extra args",
+            "info",
+            formatter_with_extra_expected_msg.format("info"),
+        ),
+        (
+            "Test warning message with extra args",
+            "warn",
+            formatter_with_extra_expected_msg.format("warning"),
+        ),
+        (
+            "Test error message with extra args",
+            "error",
+            formatter_with_extra_expected_msg.format("error"),
+        ),
+    ),
+)
+def test_with_extra_args(
+    capsys: Any, msg: str, level: str, expected: str
+) -> None:
+    logger = create_logger(format="%(addr)s:%(port)s - %(message)s")
+    dummy_log_function(logger, msg, level, addr="127.0.0.1", port=6969)
+    _, stderr = capsys.readouterr()
+    assert stderr == expected


### PR DESCRIPTION
Update and upstream tests to match the current project layout.
Remove `BaseProtocol` since it is not implemented and add suggested `MANIFEST.in` rule.